### PR TITLE
Add `testEncodeDomainType`.

### DIFF
--- a/src/test/java/io/zksync/crypto/eip712/Eip712EncoderTest.java
+++ b/src/test/java/io/zksync/crypto/eip712/Eip712EncoderTest.java
@@ -66,6 +66,13 @@ public class Eip712EncoderTest {
     }
 
     @Test
+    public void testEncodeDomainType() {
+        final String result = Eip712Encoder.encodeType(domain.intoEip712Struct());
+
+        assertEquals("EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)", result);
+    }
+
+    @Test
     public void testEncodeDomainMemberValues() {
         {
             final byte[] data = Eip712Encoder.encodeValue(domain.getName()).getValue();


### PR DESCRIPTION
I think it'd be useful to have such tests while comparing with other SDKs. E.g. on Swift I had issues with encoding because struct was named `Eip712Domain`, not `EIP712Domain`. 